### PR TITLE
Clippy recommended fixes.

### DIFF
--- a/rs/src/day13.rs
+++ b/rs/src/day13.rs
@@ -180,7 +180,7 @@ mod test {
 	fn packet_comparison() {
 		let (_, pairs) = packet_pairs(EXAMPLE).unwrap();
 
-		let expected_results = vec![true, true, false, true, false, true, false, false];
+		let expected_results = [true, true, false, true, false, true, false, false];
 
 		for ((i, (p1, p2)), &expected) in pairs.iter().enumerate().zip(expected_results.iter()) {
 			println!("== Pair {} ==", i + 1);

--- a/rs/src/day17.rs
+++ b/rs/src/day17.rs
@@ -317,7 +317,7 @@ mod test {
 		let small = Chamber { grid: small_grid };
 		assert_eq!(1, small.height());
 
-		let grid: Vec<Vec<char>> = vec![
+		let grid: Vec<Vec<char>> = [
 			"..####.", "...#...", "..###..", "####...", "..#....", "..#....",
 		]
 		.iter()
@@ -345,7 +345,7 @@ mod test {
 
 	#[test]
 	fn chamber_display_example() {
-		let grid: Vec<Vec<char>> = vec![
+		let grid: Vec<Vec<char>> = [
 			"..####.", "...#...", "..###..", "####...", "..#....", "..#....",
 		]
 		.iter()

--- a/rs/src/day2.rs
+++ b/rs/src/day2.rs
@@ -256,7 +256,7 @@ C Z";
 		let rounds = gen_day2(EXAMPLE);
 		let mut iter = rounds.iter();
 
-		let definition = vec![
+		let definition = [
 			(Hand::Rock, Hand::Rock, RoundResult::Draw, 4),
 			(Hand::Paper, Hand::Rock, RoundResult::Lose, 1),
 			(Hand::Scissors, Hand::Rock, RoundResult::Win, 7),

--- a/rs/src/day20.rs
+++ b/rs/src/day20.rs
@@ -78,7 +78,7 @@ mod test {
 
 	#[test]
 	fn parse_example_input() {
-		let expected: Vec<Element> = vec![1, 2, -3, 3, -2, 0, 4]
+		let expected: Vec<Element> = [1, 2, -3, 3, -2, 0, 4]
 			.iter()
 			.enumerate()
 			.map(|(i, &e)| (i, e))

--- a/rs/src/day23.rs
+++ b/rs/src/day23.rs
@@ -321,7 +321,7 @@ mod test {
 		let elves = elf_map(stringy_grove);
 		assert_eq!(22, elves.len());
 
-		let field: HashSet<Elf> = HashSet::from_iter(elves.clone().into_iter());
+		let field: HashSet<Elf> = HashSet::from_iter(elves.clone());
 		let grove = Grove { field };
 		assert_eq!(grove.range(), (0..=10, 1..=12));
 


### PR DESCRIPTION
Another round of cleanup removing unnecessary `vec!` macros and iterators